### PR TITLE
Get AWS region from environment variable

### DIFF
--- a/LambdaPing.nodejs
+++ b/LambdaPing.nodejs
@@ -39,7 +39,7 @@ exports.handler = function(event, context, callback) {
 
 function putCloudWatch(Domain, Success, ResponseTime, callback){
     var AWS = require('aws-sdk');
-    AWS.config.region = 'us-west-2';
+    AWS.config.region = process.env.AWS_DEFAULT_REGION;
     var cloudwatch = new AWS.CloudWatch();
     
     var params = {


### PR DESCRIPTION
Use the default AWS region by reading the environment variable provided by the Lamba execution environment.

PS: Great job on this, This is by far the best uptime function for Lambda 🥇 